### PR TITLE
Make OverrideType.None actually do nothing.

### DIFF
--- a/DefaultToolOverride/DefaultToolOverride.cs
+++ b/DefaultToolOverride/DefaultToolOverride.cs
@@ -102,6 +102,8 @@ namespace DefaultToolOverride
                     {
                         case OverrideType.Fallback:
                             return true;
+                        case OverrideType.None:
+                            return false;
                         case OverrideType.Dequip:
                             instance.StashCurrentToolOrDequip();
                             return false;


### PR DESCRIPTION
Setting `OverrideType.None` for a bind didn't work as described in the readme and would instead act identically to `OverrideType.Fallback`